### PR TITLE
Faster overwrite for NanoAODFromDAS method

### DIFF
--- a/core/python/Sample.py
+++ b/core/python/Sample.py
@@ -325,11 +325,13 @@ class Sample ( object ): # 'object' argument will disappear in Python 3
                 # if the files didn't change we don't need to read the normalization again (slowest part!)
                 logger.info("File list didn't change. Skipping.")
                 normalization = cache.getDicts({'name':name, 'DAS':DASname})[0]["normalization"]
+                logger.info('Sample %s from cache %s returned %i files.', name, dbFile, len(files))
 
             else:
                 if overwrite:
                     # remove old entry
                     cache.removeObjects({"name":name, 'DAS':DASname})
+                    logger.info("Removed old DB entry.")
 
                 if DASname.endswith('SIM') or not 'Run20' in DASname:
                     # need to read the proper normalization for MC
@@ -347,6 +349,8 @@ class Sample ( object ): # 'object' argument will disappear in Python 3
                 for f in files:
                     if cache is not None:
                         cache.add({"name":name, 'DAS':DASname, 'normalization':str(normalization)}, f, save=True)
+
+                logger.info('Found sample %s in cache %s, return %i files.', name, dbFile, len(files))
             
         if limit>0: files=files[:limit]
         sample = cls(name=name, files=files, treeName = treeName, selectionString = selectionString, weightString = weightString,

--- a/core/python/Sample.py
+++ b/core/python/Sample.py
@@ -344,7 +344,6 @@ class Sample ( object ): # 'object' argument will disappear in Python 3
                     jdata = json.load(_dasPopen(dbs))['data'][0]['summary'][0]
                     normalization = int(jdata['nevents'])
 
-#        if overwrite or n_cache_files<1:
                 for f in files:
                     if cache is not None:
                         cache.add({"name":name, 'DAS':DASname, 'normalization':str(normalization)}, f, save=True)

--- a/core/python/Sample.py
+++ b/core/python/Sample.py
@@ -288,14 +288,15 @@ class Sample ( object ): # 'object' argument will disappear in Python 3
 
         # first check if there are already files in the cache
         if n_cache_files:
-            filesFromCache = [ f["value"] for f in cache.getDicts({'name':name, 'DAS':DASname}) ]
+            filesFromCache          = [ f["value"] for f in cache.getDicts({'name':name, 'DAS':DASname}) ]
+            normalizationFromCache  = cache.getDicts({'name':name, 'DAS':DASname})[0]["normalization"]
         else:
             filesFromCache = []
 
         # if we don't want to overwrite, and there's a filelist in the cache we're already done
         if n_cache_files and not overwrite:
-            files = filesFromCache
-            normalization = cache.getDicts({'name':name, 'DAS':DASname})[0]["normalization"]
+            files           = filesFromCache
+            normalization   = normalizationFromCache
             
             logger.info('Found sample %s in cache %s, return %i files.', name, dbFile, len(files))
 
@@ -321,10 +322,10 @@ class Sample ( object ): # 'object' argument will disappear in Python 3
                     filename = redirector+'/'+line
                     files.append(filename)
             
-            if sorted(files) == sorted(filesFromCache):
-                # if the files didn't change we don't need to read the normalization again (slowest part!)
+            if sorted(files) == sorted(filesFromCache) and normalizationFromCache>0:
+                # if the files didn't change we don't need to read the normalization again (slowest part!). If the norm was 0 previously, also get it again.
                 logger.info("File list didn't change. Skipping.")
-                normalization = cache.getDicts({'name':name, 'DAS':DASname})[0]["normalization"]
+                normalization = normalizationFromCache
                 logger.info('Sample %s from cache %s returned %i files.', name, dbFile, len(files))
 
             else:

--- a/core/python/Sample.py
+++ b/core/python/Sample.py
@@ -287,6 +287,7 @@ class Sample ( object ): # 'object' argument will disappear in Python 3
             cache = None
 
         # first check if there are already files in the cache
+        normalizationFromCache = 0.
         if n_cache_files:
             filesFromCache          = [ f["value"] for f in cache.getDicts({'name':name, 'DAS':DASname}) ]
             normalizationFromCache  = cache.getDicts({'name':name, 'DAS':DASname})[0]["normalization"]

--- a/plot/python/plotting.py
+++ b/plot/python/plotting.py
@@ -462,7 +462,7 @@ def draw(plot, \
 
     for o in drawObjects:
         if o:
-            if type(o) in [ ROOT.TF1 ]:
+            if type(o) in [ ROOT.TF1, ROOT.TGraph ]:
                 o.Draw('same')
             else:
                 o.Draw()


### PR DESCRIPTION
Only overwrite the DB entry and recalculate the normalization if the file list on DAS has changed. This significantly speeds things up if only a few samples have changed.